### PR TITLE
Ft/add stack animation direction

### DIFF
--- a/lib/ios/RNNAnimationsTransitionDelegate.m
+++ b/lib/ios/RNNAnimationsTransitionDelegate.m
@@ -24,7 +24,7 @@
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext {
 	UIViewController* toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
 	UIViewController* fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
-	
+
 	[CATransaction begin];
 	[CATransaction setCompletionBlock:^{
 		[transitionContext completeTransition:![transitionContext transitionWasCancelled]];

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -207,7 +207,18 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 		[vcs removeObject:vc];
 		[nvc setViewControllers:vcs animated:[vc.resolveOptions.animations.pop.enable getWithDefaultValue:YES]];
 	}
-	
+	CATransition* transition = [CATransition animation];
+	if(vc.resolveOptions.animations.pop.animationDirection.hasValue) {
+		transition.type = kCATransitionMoveIn;
+		transition.duration = 0.33;
+		transition.subtype = kCATransitionFromLeft;
+		if([vc.resolveOptions.animations.pop.animationDirection.get isEqualToString:@"right"]) {
+			transition.subtype = kCATransitionFromRight;
+
+		}
+		transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault];
+		[nvc.view.layer addAnimation:transition forKey:kCATransition];
+	}
 	[_stackManager pop:vc animated:[vc.resolveOptions.animations.pop.enable getWithDefaultValue:YES] completion:^{
 		[_eventEmitter sendOnNavigationCommandCompletion:pop commandId:commandId params:@{@"componentId": componentId}];
 		completion();

--- a/lib/ios/RNNNavigationStackManager.m
+++ b/lib/ios/RNNNavigationStackManager.m
@@ -1,7 +1,8 @@
 #import "RNNNavigationStackManager.h"
 #import "RNNErrorHandler.h"
 #import <React/RCTI18nUtil.h>
-
+#import "RNNOptions.h"
+#import "RNNComponentViewController.h"
 typedef void (^RNNAnimationBlock)(void);
 
 @implementation RNNNavigationStackManager
@@ -22,8 +23,22 @@ typedef void (^RNNAnimationBlock)(void);
 	} else {
 		nvc.delegate = nil;
 	}
-	
+	RNNNavigationOptions * options = [(RNNComponentViewController *)animationDelegate resolveOptions];
+	CATransition* transition = [CATransition animation];
+	if(options.animations.push.animationDirection.hasValue) {
+		transition.type = kCATransitionMoveIn;
+		transition.duration = 0.33;
+		transition.subtype = kCATransitionFromLeft;
+		if([options.animations.push.animationDirection.get isEqualToString:@"right"]) {
+			transition.subtype = kCATransitionFromRight;
+		}
+		transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault];
+	}
 	[self performAnimationBlock:^{
+		if(options.animations.push.animationDirection.hasValue) {
+			[nvc.view.layer addAnimation:transition forKey:kCATransition];
+		}
+
 		[nvc pushViewController:newTop animated:animated];
 	} completion:completion];
 }
@@ -32,7 +47,7 @@ typedef void (^RNNAnimationBlock)(void);
 	if (!viewController.view.window) {
 		animated = NO;
 	}
-	
+
 	__block UIViewController *poppedVC = nil;
 	[self performAnimationBlock:^{
 		poppedVC = [viewController.navigationController popViewControllerAnimated:animated];

--- a/lib/ios/RNNScreenTransition.h
+++ b/lib/ios/RNNScreenTransition.h
@@ -9,6 +9,7 @@
 
 @property (nonatomic, strong) Bool* enable;
 @property (nonatomic, strong) Bool* waitForRender;
+@property (nonatomic, strong) Text* animationDirection;
 
 - (BOOL)hasCustomAnimation;
 - (double)maxDuration;

--- a/lib/ios/RNNScreenTransition.m
+++ b/lib/ios/RNNScreenTransition.m
@@ -10,12 +10,12 @@
 	self.bottomTabs = [[RNNElementTransitionOptions alloc] initWithDict:dict[@"bottomTabs"]];
 	self.enable = [BoolParser parse:dict key:@"enabled"];
 	self.waitForRender = [BoolParser parse:dict key:@"waitForRender"];
-
+	self.animationDirection = [TextParser parse:dict key:@"animationDirection"];
 	return self;
 }
 
 - (BOOL)hasCustomAnimation {
-	return (self.topBar.hasAnimation || self.content.hasAnimation || self.bottomTabs.hasAnimation);
+	return (self.topBar.hasAnimation || self.content.hasAnimation || self.bottomTabs.hasAnimation || self.animationDirection.hasValue );
 }
 
 - (double)maxDuration {

--- a/lib/ios/RNNStackPresenter.m
+++ b/lib/ios/RNNStackPresenter.m
@@ -23,7 +23,7 @@
 	[super applyOptions:options];
 	RNNStackController* stack = self.boundViewController;
 	RNNNavigationOptions * withDefault = [options withDefault:[self defaultOptions]];
-	
+		
 	self.interactivePopGestureDelegate = [InteractivePopGestureDelegate new];
 	self.interactivePopGestureDelegate.navigationController = stack;
 	self.interactivePopGestureDelegate.originalDelegate = stack.interactivePopGestureRecognizer.delegate;

--- a/lib/ios/RNNStackPresenter.m
+++ b/lib/ios/RNNStackPresenter.m
@@ -23,12 +23,13 @@
 	[super applyOptions:options];
 	RNNStackController* stack = self.boundViewController;
 	RNNNavigationOptions * withDefault = [options withDefault:[self defaultOptions]];
-		
+	
 	self.interactivePopGestureDelegate = [InteractivePopGestureDelegate new];
 	self.interactivePopGestureDelegate.navigationController = stack;
 	self.interactivePopGestureDelegate.originalDelegate = stack.interactivePopGestureRecognizer.delegate;
 	stack.interactivePopGestureRecognizer.delegate = self.interactivePopGestureDelegate;
-
+	
+	[stack setDirection:[withDefault.layout.direction getWithDefaultValue:@"ltr"]];
 	[stack setInteractivePopGestureEnabled:[withDefault.popGesture getWithDefaultValue:YES]];
 	[stack setRootBackgroundImage:[withDefault.rootBackgroundImage getWithDefaultValue:nil]];
 	[stack setNavigationBarTestId:[withDefault.topBar.testID getWithDefaultValue:nil]];

--- a/lib/ios/UINavigationController+RNNOptions.h
+++ b/lib/ios/UINavigationController+RNNOptions.h
@@ -30,4 +30,6 @@
 
 - (void)setBackButtonColor:(UIColor *)color;
 
+- (void)setDirection:(NSString *) direction;
+
 @end

--- a/lib/ios/UINavigationController+RNNOptions.m
+++ b/lib/ios/UINavigationController+RNNOptions.m
@@ -103,4 +103,10 @@ const NSInteger BLUR_TOPBAR_TAG = 78264802;
 	self.navigationBar.clipsToBounds = clipsToBounds;
 }
 
+- (void)setDirection:(NSString *) direction {
+	if([direction isEqualToString:@"rtl"]) {
+		self.view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+	}
+}
+
 @end

--- a/lib/src/interfaces/Options.ts
+++ b/lib/src/interfaces/Options.ts
@@ -820,6 +820,12 @@ export interface ViewAnimationOptions extends ScreenAnimationOptions {
  */
 export interface StackAnimationOptions {
   /**
+   * experimantal attempt at 
+   * Overiding default animation direction
+   */
+   animationDirection?: "right" | "left",
+
+  /**
    * Wait for the View to render before start animation
    */
   waitForRender?: boolean;


### PR DESCRIPTION
Extended react-native-navigation library with two ways of overriding animation direction for stack navigator: 
1. By applying animation in the push/pop functions of stack navigator (back gesture not affected)
2. Applying layout direction ('ltr' | 'rtl') property in RNNStackPresenter function regardless of user locale (back gesture is affected too)