### PR TITLE
increase custom top bar buttons hitslop

### DIFF
--- a/lib/ios/RNNUIBarButtonItem.m
+++ b/lib/ios/RNNUIBarButtonItem.m
@@ -14,12 +14,8 @@
 @implementation RNNUIBarButtonItem
 
 -(instancetype)init:(NSString*)buttonId withIcon:(UIImage*)iconImage {
-	UIButton* button = [[UIButton alloc] init];
-	[button addTarget:self action:@selector(onButtonPressed) forControlEvents:UIControlEventTouchUpInside];
-	[button setImage:iconImage forState:UIControlStateNormal];
-	[button setFrame:CGRectMake(0, 0, iconImage.size.width, iconImage.size.height)];
-	self = [super initWithCustomView:button];
-	self.buttonId = buttonId;
+	self = [super initWithImage:iconImage style:UIBarButtonItemStylePlain target:self action:@selector(onButtonPressed)];
+  	self.buttonId = buttonId;
 	return self;
 }
 


### PR DESCRIPTION
Increased custom top bar buttons hitslop.
Solution from [issue](https://github.com/wix/react-native-navigation/issues/5000#issuecomment-493731925)